### PR TITLE
Add dependency declaration to allow fallback feature usage. 

### DIFF
--- a/googletest/meson.build
+++ b/googletest/meson.build
@@ -1,3 +1,15 @@
 incdir = include_directories('include', '.')
 libsources = files('src/gtest-all.cc')
 mainsources = files('src/gtest_main.cc')
+
+gtest_mainless_dep = declare_dependency(
+	include_directories : incdir,
+	sources :  libsources,
+	dependencies : dependency('threads')
+)
+
+gtest_with_main_dep = declare_dependency(
+	include_directories : incdir,
+	sources :  [libsources,mainsources],
+	dependencies : dependency('threads')
+)


### PR DESCRIPTION
This pull request add two dependency declarations:
- gtest_mainless_dep  which adds gtest-all.cc as source, includes directories and a dependency to threads
- gtest_with_main_dep which does the same plus adds gtest_main.cc as source.

This allows to use depend on GTest like this:
```
gtest_dep = dependency('gtest', required : false, main : false, 
                                      fallback:['gtest','gtest_mainless_dep'])
```

instead of:
```
gtest_dep = dependency('gtest', required : false, main : false)
gtest_src = []
gtest_inc = []
if not gtest_dep.found()
   gtest_proj = subproject('gtest')
   gtest_dep = [dependency('threads')]
   gtest_src = [gtest_proj.get_variable('libsources')]
   gtest_inc = gtest_proj.get_variable('incdir')
endif
```